### PR TITLE
Zcr acoustic feature

### DIFF
--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -1,18 +1,20 @@
 import numpy as np
-
-#from scipy.io.wavfile import read
-
+import math
+from scipy.io.wavfile import read
+from librosa.feature import zero_crossing_rate as zcr_lib
 
 """
 This function returns the short time average zero crossing rate of a given
 segment. The given segment must be in numpy array form.
+The window length is given in ms.
 
 """
 
 
-def short_time_average_zcr(segment, window_size):
+def short_time_average_zcr(segment, window_length_time, sampling_freq):
 
     diff = np.diff(np.sign(segment))
+    window_size = math.ceil(window_length_time * 10e-3 * sampling_freq)
     a_term = np.abs(np.concatenate((np.array(np.sign(segment[0])), diff),
                                    axis=None))
 
@@ -27,12 +29,20 @@ def short_time_average_zcr(segment, window_size):
     return zcr
 
 
-"""
+def zcr(segment,window_length_time, hoplength):
+
+    window_size = math.ceil(window_length_time * 10e-3 * 16000)
+    hoplength=window_size
+
+    zcr_arr = zcr_lib(segment,window_size,hoplength)
+    return zcr_arr
+
 if __name__ == '__main__':
-    freq,mywav = read('/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/'
-                      'Ses01F_impro01/Ses01F_impro01_F000.wav')
+    freq,mywav = read('/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/Ses01F_impro01/Ses01F_impro01_F000.wav')
     mywav_float = mywav.astype(np.float)
-    zcr_arr = short_time_average_zcr(mywav_float, 100)
+    zcr_arr = short_time_average_zcr(mywav_float, 20, 16000)
     print(zcr_arr)
-"""
+    zcr_arr = zcr(mywav_float, 20, 20)
+    print(zcr_arr)
+
 

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -1,0 +1,22 @@
+from librosa.feature import zero_crossing_rate as
+import numpy as np
+
+
+"""
+This function returns the zcr of a wav file.
+The function takes as input the normalized wav file(in array form) the relative freq, the desirable window_size(in ms) and the desirable overlap for frame segmentation.
+The window_size is by default 20ms.
+The overlap is by default 0.5 (50ms)
+The returned value is a Zcr numpy array (each element is the zcr for each frame)
+"""
+
+def zcr(wav,freq,window_size=20,overlap=0.5):
+
+    #calculate frame's length in samples
+    frame_length = freq * window_size*(10**-3)
+    #calculate hop for overlap in samples
+    hop_length = overlap*frame_length
+
+    zcr_array = zero_crossing_rate(wav, frame_length=frame_length, hop_length=hop_length)
+
+    return zcr_array

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -4,10 +4,13 @@ import numpy as np
 
 """
 This function returns the zcr of a wav file.
-The function takes as input the normalized wav file(in numpy array form) the relative freq, the desirable window_size(in ms) and the desirable overlap for frame segmentation.
+The function takes as input the normalized wav file(in numpy array 
+form)  the relative freq, the desirable window_size(in ms) and the  
+desirable overlap for frame segmentation.
 The window_size is by default 20ms.
 The overlap is by default 0.5 (50ms)
-The returned value is a Zcr numpy array (each element is the zcr for each frame)
+The returned value is a Zcr numpy array (each element is the zcr for 
+each  frame)
 """
 
 def zcr(wav,freq,window_size=20,overlap=0.5):
@@ -17,6 +20,7 @@ def zcr(wav,freq,window_size=20,overlap=0.5):
     #calculate hop for overlap in samples
     hop_length = round(overlap*frame_length)
 
-    zcr_array = zero_crossing_rate(wav, frame_length=frame_length, hop_length=hop_length)
+    zcr_array = zero_crossing_rate(wav, frame_length=frame_length,
+                                   hop_length=hop_length)
 
     return zcr_array

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -5,21 +5,21 @@ import numpy as np
 """
 This function returns the zcr of a wav file.
 The function takes as input the normalized wav file(in numpy array 
-form)  the relative freq, the desirable window_size(in ms) and the  
-desirable overlap for frame segmentation.
-The window_size is by default 20ms.
-The overlap is by default 0.5 (50ms)
+form)  the relative freq, the desirable window_size(in samples) and the  
+desirable overlap for frame segmentation in samples too.
+The window_size is by default 2048 samples.
+The hop (used for overlap) is by default 512 samples.
 The returned value is a Zcr numpy array (each element is the zcr for 
 each  frame)
 """
 
 
-def zcr(wav,freq,window_size=20,overlap=0.5):
+def zcr(wav, window_size=2048, hop=512):
 
-    # calculate frame's length in samples
-    frame_length =round(freq * window_size*(10**-3))
-    # calculate hop for overlap in samples
-    hop_length = round((1-overlap)*frame_length)
+    # frame's length in samples
+    frame_length =window_size
+    # hop for overlap in samples
+    hop_length = hop
 
     zcr_array = zero_crossing_rate(wav, frame_length=frame_length,
                                    hop_length=hop_length)

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -1,9 +1,6 @@
 import numpy as np
 
-import scipy.io.wavfile import read
-
-from librosa.feature import zero_crossing_rate
-
+#from scipy.io.wavfile import read
 
 
 """
@@ -18,17 +15,29 @@ each  frame)
 """
 
 
-def zcr(wav, window_size=2048, hop=512):
+def short_time_average_zcr(segment, window_size):
 
-    # frame's length in samples
-    frame_length =window_size
-    # hop for overlap in samples
-    hop_length = hop
+    diff = np.diff(np.sign(segment))
+    a_term = np.abs(np.concatenate((np.array(np.sign(segment[0])), diff),
+                                   axis=None))
 
-    zcr_array = zero_crossing_rate(wav, frame_length=frame_length,
-                                   hop_length=hop_length)
+    zcr = np.zeros(window_size-1)
+    for n in range(0, window_size-1):
+        summary = 0
+        for m in range(0, len(segment)-1):
+            if n-m >= 0 and n <= m+window_size-1:
+                summary = summary + a_term[m] * 1/(2*window_size)
+        zcr[n] = summary
 
-    return zcr_array
+    return zcr
 
 
-if __name__== 'main':
+"""
+if __name__ == '__main__':
+    freq,mywav = read('/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/'
+                      'Ses01F_impro01/Ses01F_impro01_F000.wav')
+    mywav_float = mywav.astype(np.float)
+    zcr_arr = short_time_average_zcr(mywav_float, 100)
+    print(zcr_arr)
+"""
+

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -4,14 +4,9 @@ import numpy as np
 
 
 """
-This function returns the zcr of a wav file.
-The function takes as input the normalized wav file(in numpy array 
-form)  the relative freq, the desirable window_size(in samples) and the  
-desirable overlap for frame segmentation in samples too.
-The window_size is by default 2048 samples.
-The hop (used for overlap) is by default 512 samples.
-The returned value is a Zcr numpy array (each element is the zcr for 
-each  frame)
+This function returns the short time average zero crossing rate of a given
+segment. The given segment must be in numpy array form.
+
 """
 
 

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -13,12 +13,13 @@ The returned value is a Zcr numpy array (each element is the zcr for
 each  frame)
 """
 
+
 def zcr(wav,freq,window_size=20,overlap=0.5):
 
-    #calculate frame's length in samples
+    # calculate frame's length in samples
     frame_length =round(freq * window_size*(10**-3))
-    #calculate hop for overlap in samples
-    hop_length = round(overlap*frame_length)
+    # calculate hop for overlap in samples
+    hop_length = round((1-overlap)*frame_length)
 
     zcr_array = zero_crossing_rate(wav, frame_length=frame_length,
                                    hop_length=hop_length)

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -1,10 +1,10 @@
-from librosa.feature import zero_crossing_rate as
+from librosa.feature import zero_crossing_rate
 import numpy as np
 
 
 """
 This function returns the zcr of a wav file.
-The function takes as input the normalized wav file(in array form) the relative freq, the desirable window_size(in ms) and the desirable overlap for frame segmentation.
+The function takes as input the normalized wav file(in numpy array form) the relative freq, the desirable window_size(in ms) and the desirable overlap for frame segmentation.
 The window_size is by default 20ms.
 The overlap is by default 0.5 (50ms)
 The returned value is a Zcr numpy array (each element is the zcr for each frame)
@@ -13,9 +13,9 @@ The returned value is a Zcr numpy array (each element is the zcr for each frame)
 def zcr(wav,freq,window_size=20,overlap=0.5):
 
     #calculate frame's length in samples
-    frame_length = freq * window_size*(10**-3)
+    frame_length =round(freq * window_size*(10**-3))
     #calculate hop for overlap in samples
-    hop_length = overlap*frame_length
+    hop_length = round(overlap*frame_length)
 
     zcr_array = zero_crossing_rate(wav, frame_length=frame_length, hop_length=hop_length)
 

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -1,48 +1,40 @@
 import numpy as np
-import math
-from scipy.io.wavfile import read
 from librosa.feature import zero_crossing_rate as zcr_lib
 
 """
-This function returns the short time average zero crossing rate of a given
-segment. The given segment must be in numpy array form.
+This function returns the zcr of a given
+segment. 
+The given segment must be in numpy array form (float).
 The window length is given in ms.
-
+The return value is a float numpy array. 
 """
 
 
-def short_time_average_zcr(segment, window_length_time, sampling_freq):
+def zcr(segment,window_length=2048, overlap=0, freq=16000):
 
-    diff = np.diff(np.sign(segment))
-    window_size = math.ceil(window_length_time * 10e-3 * sampling_freq)
-    a_term = np.abs(np.concatenate((np.array(np.sign(segment[0])), diff),
-                                   axis=None))
+    frame_size = window_length
 
-    zcr = np.zeros(window_size-1)
-    for n in range(0, window_size-1):
-        summary = 0
-        for m in range(0, len(segment)-1):
-            if n-m >= 0 and n <= m+window_size-1:
-                summary = summary + a_term[m] * 1/(2*window_size)
-        zcr[n] = summary
+    samples = freq * overlap * 10e-3
+    print(samples)
+    assert  samples < frame_size,\
+        "The given overlap extends in zcr frame's size."
 
-    return zcr
+    hoplength = int(frame_size - samples)
 
+    zcr_arr = zcr_lib(segment, frame_length=frame_size,
+                      hop_length=hoplength, center=True)
 
-def zcr(segment,window_length_time, hoplength):
+    return zcr_arr.squeeze()
 
-    window_size = math.ceil(window_length_time * 10e-3 * 16000)
-    hoplength=window_size
-
-    zcr_arr = zcr_lib(segment,window_size,hoplength)
-    return zcr_arr
 
 if __name__ == '__main__':
-    freq,mywav = read('/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/Ses01F_impro01/Ses01F_impro01_F000.wav')
-    mywav_float = mywav.astype(np.float)
-    zcr_arr = short_time_average_zcr(mywav_float, 20, 16000)
-    print(zcr_arr)
-    zcr_arr = zcr(mywav_float, 20, 20)
-    print(zcr_arr)
+    from scipy.io.wavfile import read
+    freq, wav = read('/home/manzar/Desktop/IEMOCAP/Session1/sen'
+                     'tences/wav/Ses01F_impro01/Ses01F_impro01_F000.wav')
+
+    mywav_float= wav.astype(np.float)
+    print(mywav_float.shape)
+    b = zcr(mywav_float,window_length=2048, overlap=0)
+    print(b.shape)
 
 

--- a/crossmodal/features_extractor/audio_features/zcr.py
+++ b/crossmodal/features_extractor/audio_features/zcr.py
@@ -1,5 +1,9 @@
-from librosa.feature import zero_crossing_rate
 import numpy as np
+
+import scipy.io.wavfile import read
+
+from librosa.feature import zero_crossing_rate
+
 
 
 """
@@ -25,3 +29,6 @@ def zcr(wav, window_size=2048, hop=512):
                                    hop_length=hop_length)
 
     return zcr_array
+
+
+if __name__== 'main':


### PR DESCRIPTION
This function returns the zcr feature of a wav file.
The function takes as input the normalized wav file(in numpy array form) the relative freq, the desirable window size(in ms) and the desirable overlap for frame segmentation.
The window size is by default 20ms.
The overlap is by default 0.5 (50ms)
The returned value is a Zcr numpy array (each element is the zcr for each frame)