### PR TITLE
Short time energy acoustic feature

### DIFF
--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -19,13 +19,13 @@ Return value: the mean of the short time energies (extracted from each frame).
 """
 
 
-def short_time_energy(segment, window_size=2048, overlap=20, freq=16000):
+def short_time_energy(segment, window_size=2048, overlap=0, freq=16000):
 
     # frame's length in samples
     frame_length = window_size
 
     # calculate hop length
-    samples = freq * overlap *1e-3
+    samples = freq * overlap * 10e-3
 
     assert samples < window_size,"The given overlap is more than frame's size"
 
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     audio_array = (np.asarray(wav.get_array_of_samples())).astype(np.float64)
     audio_freq = wav.frame_rate
     print(audio_array.shape)
-    a = short_time_energy(audio_array,window_size=2048,overlap=0)
+    a = short_time_energy(audio_array,window_size=2048)
     print(a.shape)
 
 

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -43,9 +43,7 @@ def short_time_energy(segment, window_size=2048, overlap=20, freq=16000):
 
 
 if __name__ == "__main__":
-
-
+    from pydub import AudioSegment
     path = '/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/Ses01M_impro01/Ses01M_impro01_M000.wav'
-    
-    b = short_time_energy(a,2,overlap=0)
-    print(b)
+    wav = AudioSegment.from_wav(path)
+    print(wav)

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -4,25 +4,26 @@ import numpy as np
 """
 This function returns the short_time_energy of a wav file.
 The function takes as input the normalized wav file(in numpy array
-form)  the relative freq, the desirable window_size(in ms) and the
-desirable overlap for frame segmentation.
-The window_size is by default 20ms.
-The overlap is by default 0.5 (50ms)
+form)  the relative freq, the desirable window_size(frame size) and the
+desirable overlap for frame segmentation (in samples).
+The window_size is by default 2048 samples.
+The hop (used for overlapping) is by default 512 samples. 
 The returned value is a short time energy numpy array (each element 
 is  the short time energy for each  frame)
 """
 
 
-def short_time_energy(wav, freq, window_size=20, overlap=0.5):
+def short_time_energy(wav, window_size=2048, hop=512):
 
-    # calculate frame's length in samples
-    frame_length = round(freq * window_size*(10**-3))
-    # calculate hop for overlap in samples
-    hop_length = round((1-overlap)*frame_length)
+    # frame's length in samples
+    frame_length = window_size
+
+    hop_length = hop
 
     rmse_vector = rmse(y=wav, frame_length=frame_length,
                        hop_length=hop_length)
 
+    #calculate short time energy from rmse
     short_time_energy_vector = np.power(rmse_vector, 2) * frame_length
 
     return short_time_energy_vector

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -24,26 +24,32 @@ def short_time_energy(segment, window_size=2048, overlap=20, freq=16000):
     # frame's length in samples
     frame_length = window_size
 
-    #calculate hop length
+    # calculate hop length
     samples = freq * overlap *1e-3
 
     assert samples < window_size,"The given overlap is more than frame's size"
 
+    hop_length = int(frame_length - samples)
 
-    hop_length = frame_length - samples
-
-    #calculat rmse
+    # calculate rmse
     rmse_vector = rmse(y=segment, frame_length=frame_length,
-                       hop_length=hop_length)
+                       hop_length=hop_length,center=True)
 
-    #calculate short time energy from rmse
+    # calculate short time energy from rmse
     short_time_energy_vector = np.power(rmse_vector, 2) * frame_length
 
-    return short_time_energy_vector
+    return short_time_energy_vector.squeeze()
 
 
 if __name__ == "__main__":
     from pydub import AudioSegment
     path = '/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/Ses01M_impro01/Ses01M_impro01_M000.wav'
     wav = AudioSegment.from_wav(path)
-    print(wav)
+    audio_array = (np.asarray(wav.get_array_of_samples())).astype(np.float64)
+    audio_freq = wav.frame_rate
+    print(audio_array.shape)
+    a = short_time_energy(audio_array,window_size=2048,overlap=0)
+    print(a.shape)
+
+
+

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -2,14 +2,8 @@ from librosa.feature import rmse
 import numpy as np
 
 """
-This function returns the short_time_energy of a wav file.
-The function takes as input the normalized wav file(in numpy array
-form)  the relative freq, the desirable window_size(frame size) and the
-desirable overlap for frame segmentation (in samples).
-The window_size is by default 2048 samples.
-The hop (used for overlapping) is by default 512 samples. 
-The returned value is a short time energy numpy array (each element 
-is  the short time energy for each  frame)
+This function returns the short time energy of a given segment. The sigment
+must be in numpy array form.
 """
 
 

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -1,5 +1,6 @@
 from librosa.feature import rmse
 import numpy as np
+
 """
 This function returns the short_time_energy of a wav file.
 The function takes as input the normalized wav file(in numpy array

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -2,19 +2,38 @@ from librosa.feature import rmse
 import numpy as np
 
 """
-This function returns the short time energy of a given segment. The sigment
+This function returns the short time energy of a given segment. The segment
 must be in numpy array form.
+
+This function takes as inputs:
+
+segment: a numpy array (float) representing the current segment from which we
+will receive the short time energy.
+
+window_size: librosa.rmse cuts into frames the given segment, so the 
+window_size represents the length of each frame.
+
+overlap: the overlap that the frames will with each other. It is given in msec.
+
+Return value: the mean of the short time energies (extracted from each frame).
 """
 
 
-def short_time_energy(wav, window_size=2048, hop=512):
+def short_time_energy(segment, window_size=2048, overlap=20, freq=16000):
 
     # frame's length in samples
     frame_length = window_size
 
-    hop_length = hop
+    #calculate hop length
+    samples = freq * overlap *1e-3
 
-    rmse_vector = rmse(y=wav, frame_length=frame_length,
+    assert samples < window_size,"The given overlap is more than frame's size"
+
+
+    hop_length = frame_length - samples
+
+    #calculat rmse
+    rmse_vector = rmse(y=segment, frame_length=frame_length,
                        hop_length=hop_length)
 
     #calculate short time energy from rmse
@@ -22,3 +41,11 @@ def short_time_energy(wav, window_size=2048, hop=512):
 
     return short_time_energy_vector
 
+
+if __name__ == "__main__":
+
+
+    path = '/home/manzar/Desktop/IEMOCAP/Session1/sentences/wav/Ses01M_impro01/Ses01M_impro01_M000.wav'
+    
+    b = short_time_energy(a,2,overlap=0)
+    print(b)

--- a/crossmodal/features_extractor/audio_features/short_time_energy.py
+++ b/crossmodal/features_extractor/audio_features/short_time_energy.py
@@ -1,0 +1,28 @@
+from librosa.feature import rmse
+import numpy as np
+"""
+This function returns the short_time_energy of a wav file.
+The function takes as input the normalized wav file(in numpy array
+form)  the relative freq, the desirable window_size(in ms) and the
+desirable overlap for frame segmentation.
+The window_size is by default 20ms.
+The overlap is by default 0.5 (50ms)
+The returned value is a short time energy numpy array (each element 
+is  the short time energy for each  frame)
+"""
+
+
+def short_time_energy(wav, freq, window_size=20, overlap=0.5):
+
+    # calculate frame's length in samples
+    frame_length = round(freq * window_size*(10**-3))
+    # calculate hop for overlap in samples
+    hop_length = round((1-overlap)*frame_length)
+
+    rmse_vector = rmse(y=wav, frame_length=frame_length,
+                       hop_length=hop_length)
+
+    short_time_energy_vector = np.power(rmse_vector, 2) * frame_length
+
+    return short_time_energy_vector
+


### PR DESCRIPTION
This function returns the short time energy of a wav file.
The function takes as input the normalized wav file(in numpy array
form)  the relative freq, the desirable window_size(in ms) and the
desirable overlap for frame segmentation.
The window_size is by default 20ms.
The overlap is by default 0.5 (50ms)
The returned value is a short time energy numpy array (each element 
is  the short time energy for each  frame)